### PR TITLE
Fixes greedy lib ignore, will ignore *all* lib folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist
 node_modules
 npm-debug.log
-lib
+/lib


### PR DESCRIPTION
Found out the hard way after switching to master and back to migrate-webpack :laughing: 