### PR TITLE
Fast reloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist
 node_modules
 npm-debug.log
-lib
+/lib

--- a/webpack/webpack.config.client.dev.js
+++ b/webpack/webpack.config.client.dev.js
@@ -5,13 +5,18 @@ var _ = require('lodash');
 var devProps = require('./devProps');
 
 var config = module.exports = _.assign(_.cloneDeep(config), {
-  devtool: 'source-map',
+  // http://webpack.github.io/docs/build-performance.html#sourcemaps
+  //devtool: 'eval',             // fastest - readable source maps
+  //devtool: 'source-map',       // slowest - best source maps
+  devtool: 'eval-source-map',    // best of both worlds
+  cache: true,
   entry: [
     'webpack-dev-server/client?' + devProps.baseUrl,
     'webpack/hot/only-dev-server',
   ].concat(config.entry),
   output: _.assign(_.cloneDeep(config.output), {
     publicPath: devProps.baseUrl + '/assets/',
+    pathinfo: true,
   }),
   plugins: (config.plugins || []).concat([
     new webpack.HotModuleReplacementPlugin(),
@@ -36,3 +41,4 @@ var jsLoader = _.find(config.module.loaders, function(loader) {
 if (jsLoader) {
   jsLoader.loader = 'react-hot!' + jsLoader.loader;
 }
+


### PR DESCRIPTION
fixes #33 . Uses a faster method for generating source maps. Defaults to using a middle of the road setting which cuts down reloads by half-ish. If you use 'eval' you can get sub second reloads ( ~0.6s). 

Still generates good looking source maps which I think is important for a default. Different options are commented out for ease of use.