### PR TITLE
Fix lib exclude

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,19 @@
+{
+  "stage": 0,
+  "plugins": [
+    "react-transform"
+  ],
+  "extra": {
+    "react-transform": [{
+      "target": "react-transform-webpack-hmr",
+
+      // if you use React Native, pass "react-native" instead:
+      "imports": ["react"],
+
+      // this is important for Webpack HMR:
+      "locals": ["module"]
+    }]
+    // note: you can put more transforms into array
+    // this is just one of them!
+  }
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,19 +1,20 @@
 {
   "stage": 0,
-  "plugins": [
-    "react-transform"
-  ],
-  "extra": {
-    "react-transform": [{
-      "target": "react-transform-webpack-hmr",
-
-      // if you use React Native, pass "react-native" instead:
-      "imports": ["react"],
-
-      // this is important for Webpack HMR:
-      "locals": ["module"]
-    }]
-    // note: you can put more transforms into array
-    // this is just one of them!
-  }
+    "plugins": [
+      "react-transform"
+      ],
+    "extra": {
+      "react-transform": [{
+        "target": "react-transform-webpack-hmr",
+        "imports": ["react"],
+        // this is important for Webpack HMR:
+        "locals": ["module"]
+      },
+      {
+        "target": "react-transform-catch-errors",
+        // the second import is the React component to render error
+        // (it can be a local path too, like "./src/ErrorReporter")
+        "imports": ["react", "redbox-react"]
+      }]
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # meteor-webpack-react
 
 THis is a Meteor project skeleton where the client (in React) and server get built by Webpack.  In dev mode,
-webpack-dev-server is used with react-hot-loader.  There are a bunch of run and build scripts to make things more
+webpack-dev-server is used with [react-transform](https://github.com/gaearon/babel-plugin-react-transform).  There are a bunch of run and build scripts to make things more
 convenient.
 
 There is a port of the Meteor simple-todos tutorial to this stack on the `simple-todos` branch.
@@ -9,7 +9,7 @@ There is a port of the Meteor simple-todos tutorial to this stack on the `simple
 ## Advantages of packaging with Webpack instead of Meteor
 
 * `require`/ES6 `import` let you avoid Meteor global variables/load order issues
-* `react-hot-loader` reloads React components without reloading the entire page
+* `react-transform` reloads React components without reloading the entire page
   when you make changes
 * If you `require` your styles with Webpack, it will also reload them without
   reloading the entire page when you make changes to them
@@ -39,10 +39,10 @@ In dev mode, both `webpack-dev-server` and `meteor_core` run simultaneously on d
 
 This is where it gets tricky, but there is an experimental solution in the `react-commons` branch.
 
-`react-hot-loader` requires many internal React modules, thus it doesn't work with components
+`react-transform` requires many internal React modules, thus it doesn't work with components
 created by an instance of React loaded from `react-runtime-dev`.
 
-But if React is loaded by Webpack, then the the modules required by `react-hot-loader`
+But if React is loaded by Webpack, then the the modules required by `react-transform`
 will be the same as in that instance of React.
 
 This poses a problem if you want to use any Meteor packages that depend on the `react` package,
@@ -107,9 +107,9 @@ Put your settings in `settings/devel.json` & `settings/prod.json` and they will 
 
 ## Running Meteor Commands
 
-As a convenince you can run `./met` in the root directory to run the `meteor` command. However you can still `cd meteor_core` and then run `meteor` from that directory as well.
+As a convenience you can run `./met` in the root directory to run the `meteor` command. However you can still `cd meteor_core` and then run `meteor` from that directory as well.
 
 ```
 ./met  --version
-./met search moment
+./met search simple-schema
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "node-libs-browser": "^0.5.2",
+    "react-transform-catch-errors": "^0.1.1",
     "react-transform-webpack-hmr": "^0.1.4",
+    "redbox-react": "^1.0.1",
     "style-loader": "^0.12.3",
     "webpack": "^1.10.1",
     "webpack-dev-server": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "devDependencies": {
     "babel-eslint": "^4.0.5",
     "babel-loader": "^5.1.2",
+    "babel-plugin-react-transform": "^1.0.3",
     "css-loader": "^0.15.3",
     "eslint-config-airbnb": "0.0.7",
     "eslint-plugin-react": "^3.2.2",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "node-libs-browser": "^0.5.2",
-    "react-hot-loader": "^1.2.7",
+    "react-transform-webpack-hmr": "^0.1.4",
     "style-loader": "^0.12.3",
     "webpack": "^1.10.1",
     "webpack-dev-server": "^1.10.1"

--- a/webpack/webpack.config.client.dev.js
+++ b/webpack/webpack.config.client.dev.js
@@ -1,7 +1,6 @@
 var webpack = require('webpack');
 var config = require('./webpack.config.client');
 var _ = require('lodash');
-
 var devProps = require('./devProps');
 
 var config = module.exports = _.assign(_.cloneDeep(config), {
@@ -31,14 +30,3 @@ var config = module.exports = _.assign(_.cloneDeep(config), {
     port: devProps.webpackPort,
   }
 });
-
-// inject react-hot loader
-
-var jsLoader = _.find(config.module.loaders, function(loader) {
-  return loader.test.test('.js');
-});
-
-if (jsLoader) {
-  jsLoader.loader = 'react-hot!' + jsLoader.loader;
-}
-

--- a/webpack/webpack.config.client.js
+++ b/webpack/webpack.config.client.js
@@ -23,7 +23,7 @@ module.exports = {
     loaders: [
       {
         test: /\.jsx?$/,
-        loader: 'babel?stage=0',
+        loader: 'babel',
         exclude: /node_modules|lib/,
       },
       {

--- a/webpack/webpack.config.client.js
+++ b/webpack/webpack.config.client.js
@@ -24,11 +24,12 @@ module.exports = {
       {
         test: /\.jsx?$/,
         loader: 'babel',
-        exclude: /node_modules|lib/,
+        exclude: [/node_modules/, path.join(__dirname, '../lib')],
       },
       {
         test: /\.css$/,
-        loader: 'style-loader!css-loader'
+        loader: 'style-loader!css-loader',
+        exclude: /node_modules/,
       },
     ],
   },


### PR DESCRIPTION
This fixes the last of my lib issues. I had a component lib folder that had mixins for that component and I happened to name it `lib/`. This only ignores the lib in the root folder.

However, perhaps a better fix is to move `./lib` into `webpack/lib/*` since it's used specifically for webpack builds. This would allow an easier path to ignore and move it out of the root.