### PR TITLE
Fix core-js build when using npm 3

### DIFF
--- a/core-js-custom-build
+++ b/core-js-custom-build
@@ -7,18 +7,18 @@ popd > /dev/null
 WEBPACK_DIR="$SCRIPTPATH/webpack"
 LIB_DIR="$WEBPACK_DIR/lib"
 
-CORE_JS_VERSION=`node echoPackageVersion.js node_modules/babel-core/node_modules/core-js/package.json`
+CORE_JS_VERSION=`node echoPackageVersion.js node_modules/core-js/package.json`
 
 [ ! -d "$LIB_DIR" ] && mkdir "$LIB_DIR"
 
 if [ ! -f "$LIB_DIR/core-js-no-number-${CORE_JS_VERSION}.js" ]
 then
   echo Building core-js@${CORE_JS_VERSION} without ES6 number constructor...
-  cd node_modules/babel-core/node_modules/core-js
+  cd node_modules/core-js
   npm install
   cd "$SCRIPTPATH"
   npm run build-core-js
-  mv node_modules/babel-core/node_modules/core-js/core-js-no-number.js "$LIB_DIR/core-js-no-number-${CORE_JS_VERSION}.js"
+  mv node_modules/core-js/core-js-no-number.js "$LIB_DIR/core-js-no-number-${CORE_JS_VERSION}.js"
   cd "$LIB_DIR"
   ln -sf core-js-no-number-${CORE_JS_VERSION}.js core-js-no-number.js
 else

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A port of simple-todos to Webpack/React on the frontend",
   "repository": "https://www.github.com/jedwards1211/meteor-webpack-react",
   "devDependencies": {
+    "core-js": "^1.0.0",
     "babel": "^5.8.21",
     "babel-core": "^5.8.22",
     "babel-eslint": "^4.0.5",
@@ -36,7 +37,7 @@
     "build": "webpack/scripts/build.sh",
     "test-built": "webpack/scripts/test-built.sh",
     "lint": "eslint app",
-    "build-core-js": "grunt --gruntfile node_modules/babel-core/node_modules/core-js/Gruntfile.js build:es5,es6,es7,js,web --blacklist=es6.number.constructor --path=core-js-no-number"
+    "build-core-js": "grunt --gruntfile node_modules/core-js/Gruntfile.js build:es5,es6,es7,js,web --blacklist=es6.number.constructor --path=core-js-no-number"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
Don't rely on `core-js` in `babel-core` directory but add it as top level dependency.
Fixes build after `npm install` with npm 3 and later.

See #50 