### PR TITLE
WIP: Code splitting and serve through webpack-dev-server

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -9,12 +9,6 @@ Meteor.call('sayHello', function(err, res) {
   console.log(res);
 });
 
-if (Meteor.isServer) {
-  // Template does not support server side
-  var Template = {
-    loginButtons: 'any'
-  };
-}
 
 @reactMixin.decorate(ReactMeteorData)
 export default class App extends Component {
@@ -25,11 +19,15 @@ export default class App extends Component {
   }
 
   render() {
+    // Template does not support server side
+    let _Template = typeof(Template) === 'function' ? Template : {
+      loginButtons: 'any'
+    };
     let userCount = Users.find().fetch().length;
     let postsCount = Posts.find().fetch().length;
     return (
       <div className="App">
-        <BlazeTemplate template={Template.loginButtons} />
+        <BlazeTemplate template={_Template.loginButtons} />
         <h1>Hello Webpack!</h1>
         <p>There are {userCount} users in the Minimongo  (login to change)</p>
         <p>There are {postsCount} posts in the Minimongo  (autopublish removed)</p>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "source-map-support": "^0.3.2",
     "style-loader": "^0.12.3",
     "webpack": "^1.10.1",
-    "webpack-dev-server": "^1.10.1"
+    "webpack-dev-server": "^1.10.1",
+    "webpack-split-by-path": "0.0.6"
   },
   "dependencies": {
     "classnames": "^2.1.3",

--- a/webpack/loadClientBundle.html
+++ b/webpack/loadClientBundle.html
@@ -1,10 +1,5 @@
 <head>
-  <script type="text/javascript">
-    // unfortunately it's not possible to make a URL relative to the current host with a different port,
-    // so the URL must be created by script like this if we want to test on devices besides localhost.
-    var scriptElem = document.createElement('script');
-    scriptElem.type = 'text/javascript';
-    scriptElem.src = /https?:\/\/[^:\/]+/.exec(window.location.href)[0] + ':9090/assets/client.bundle.js';
-    document.head.appendChild(scriptElem);
-  </script>
+  <!-- load webpack bundles -->
+  <script src="/assets/vendor.bundle.js"></script>
+  <script src="/assets/app.bundle.js"></script>
 </head>

--- a/webpack/webpack.config.client.dev.js
+++ b/webpack/webpack.config.client.dev.js
@@ -4,11 +4,12 @@ var _ = require('lodash');
 var devProps = require('./devProps');
 
 var config = module.exports = _.assign(_.clone(config), {
-  devtool: 'eval',
-  entry: [
-    'webpack-dev-server/client?' + devProps.baseUrl,
-    'webpack/hot/only-dev-server',
-  ].concat(config.entry),
+  entry: {
+    app: [
+      'webpack-dev-server/client?' + devProps.baseUrl,
+      'webpack/hot/only-dev-server',
+    ].concat(config.entry.app),
+  },
   output: _.assign(_.clone(config.output), {
     publicPath: devProps.baseUrl + '/assets/',
     pathinfo: true,
@@ -56,13 +57,21 @@ var config = module.exports = _.assign(_.clone(config), {
   plugins: (config.plugins || []).concat([
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
+    // disable build of source maps for node_modules (vendor)
+    new webpack.EvalSourceMapDevToolPlugin({
+      filename: '[file].map',
+      exclude: ['vendor.bundle.js'],
+    }),
   ]),
   devServer: {
     publicPath: devProps.baseUrl + '/assets/',
     host: devProps.host,
     hot: true,
     historyApiFallback: true,
-    contentBase: devProps.contentBase,
+    contentBase: devProps.baseUrl,
     port: devProps.webpackPort,
+    proxy: {
+      "*": devProps.contentBase
+    }
   }
 });

--- a/webpack/webpack.config.client.dev.js
+++ b/webpack/webpack.config.client.dev.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var devProps = require('./devProps');
 
 var config = module.exports = _.assign(_.clone(config), {
+  devTool: 'eval-cheap-module-source-map',
   entry: {
     app: [
       'webpack-dev-server/client?' + devProps.baseUrl,
@@ -58,9 +59,11 @@ var config = module.exports = _.assign(_.clone(config), {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     // disable build of source maps for node_modules (vendor)
-    new webpack.EvalSourceMapDevToolPlugin({
+    new webpack.SourceMapDevToolPlugin({
       filename: '[file].map',
       exclude: ['vendor.bundle.js'],
+      columns: false, // no columns in SourceMaps, faster
+      module: true // use SourceMaps from loaders
     }),
   ]),
   devServer: {

--- a/webpack/webpack.config.client.js
+++ b/webpack/webpack.config.client.js
@@ -1,16 +1,20 @@
 var path = require('path');
 var webpack = require('webpack');
+var SplitByPathPlugin = require('webpack-split-by-path');
 
 module.exports = {
   context: __dirname,
-  entry: [
-    './lib/core-js-no-number',
-    'regenerator/runtime',
-    '../app/main_client',
-  ],
+  entry: {
+    app: [
+      './lib/core-js-no-number',
+      'regenerator/runtime',
+      '../app/main_client',
+    ],
+  },
   output: {
     path: path.join(__dirname, 'assets'),
-    filename: 'client.bundle.js',
+    filename: '[name].bundle.js',
+    chunkFilename: '[name].bundle.js',
     publicPath: '/assets/',
   },
   resolve: {
@@ -32,6 +36,13 @@ module.exports = {
   },
   plugins: [
     new webpack.PrefetchPlugin("react"),
-    new webpack.PrefetchPlugin("react/lib/ReactComponentBrowserEnvironment")
+    new webpack.PrefetchPlugin("react/lib/ReactComponentBrowserEnvironment"),
+    // split node_modules into separate bundle (vendor)
+    new SplitByPathPlugin([
+      {
+        name: 'vendor',
+        path: path.join(__dirname, '../node_modules'),
+      }
+    ]),
   ]
 };


### PR DESCRIPTION
This PR configures webpack to split everything in `node_modules` directory into a separate bundle (`vendor.bundle.js`).
While figuring out how to to this, I also found the `proxy` option in webpack-dev-server configuration and got it working with meteor. What it does:

All requests to 0.0.0.0:9090 are forwarded to 0.0.0.0:3000 - except assets generated by the dev server.
This solves some issues:
-  The bundles are served from the same port as the webpage, so the script used to generate the `<script>` tag is not needed anymore
- Hot reload works also after errors in JSX code - no more CORS related issues. At least I got any them since. Should fix #45 

Unsolved / TODO:
- [ ] test production builds/deploy
- [ ] `WebSocket connection failed` [1] error on every reload
- [ ] `XHR finished loading` info logs spam in console, change loglevel somehow


[1] `WebSocket connection to 'ws://0.0.0.0:9090/sockjs/154/timeznho/websocket' failed: Connection closed before receiving a handshake response` - Does not seem to cause issues but doesn't look nice