### PR TITLE
Directly build to core-js without grunt-cli

### DIFF
--- a/core-js-custom-build.js
+++ b/core-js-custom-build.js
@@ -2,25 +2,32 @@ require('shelljs/global');
 var dirs = require('./dirs');
 var fs = require('fs');
 var path = require('path');
+var coreJsBuild = require('core-js/build');
 
 dirs.lib = path.join(dirs.webpack, 'lib');
 if (!fs.existsSync(dirs.lib)) mkdir(dirs.lib);
 
-
 var coreJsVersion = JSON.parse(fs.readFileSync('node_modules/core-js/package.json')).version;
-var targetFile = 'core-js-no-number-' + coreJsVersion + '.js';
+var targetFileName = 'core-js-no-number.js';
+var currentFileExist = fs.existsSync(path.join(dirs.lib, targetFileName));
+var currentFileFewLines = currentFileExist ?
+  fs.readFileSync(path.join(dirs.lib, targetFileName)).toString().substr(0, 130) : '';
+var currentFileVersionRegex = /core-js (\d.\d.\d+)/m;
+var currentFileVersion = currentFileVersionRegex.test(currentFileFewLines) ?
+  currentFileVersionRegex.exec(currentFileFewLines)[1] : false;
 
-if (!fs.existsSync(path.join(dirs.lib, targetFile))) {
+if (coreJsVersion !== currentFileVersion) {
   echo('Building core-js@' + coreJsVersion + ' without ES6 number constructor...');
-  cd('node_modules/core-js');
-  exec('npm install');
-  cd(__dirname);  
-  exec('npm run build-core-js');
-  cd('node_modules/core-js');
-  mv('core-js-no-number.js', path.join(dirs.lib, targetFile));
-  rm('-rf', 'node_modules');
-  cd(dirs.lib);
-  ln('-sf', targetFile, 'core-js-no-number.js');
+  coreJsBuild({
+    modules: ['es5', 'es6', 'es7', 'js', 'web'],
+    blacklist: ['es6.number.constructor'],
+  }, function(error, code) {
+    if (error) {
+      console.error('core-js build error');
+      return;
+    }
+    fs.writeFileSync(path.join(dirs.lib, targetFileName), code);
+  });
 }
 else {
   echo('core-js@' + coreJsVersion + ' without ES6 number constructor is up to date');

--- a/dev.js
+++ b/dev.js
@@ -34,7 +34,7 @@ var loadClientBundleLink = path.join(dirs.meteor, 'client/loadClientBundle.html'
 
 var requireServerBundleJs = path.join(dirs.meteor, 'server/require.server.bundle.js');
 
-require('./core-js-custom-build');
+exec('node core-js-custom-build.js');
 
 if (fs.existsSync(clientBundleLink)) rm(clientBundleLink);
 if (fs.existsSync(serverBundleLink)) rm(serverBundleLink);
@@ -52,7 +52,7 @@ serverCompiler.watch({
     serverBundleReady = true;
     compileClient();
     runMeteor();
-  }  
+  }
 });
 
 function compileClient() {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,10 @@
     "babel-eslint": "^4.0.5",
     "babel-loader": "^5.1.2",
     "babel-plugin-react-transform": "^1.1.0",
-    "core-js": "^1.0.0",
+    "core-js": "^1.2.2",
     "css-loader": "^0.15.3",
     "eslint-config-airbnb": "0.0.7",
     "eslint-plugin-react": "^3.2.2",
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
     "karma": "^0.13.9",
     "karma-chrome-launcher": "^0.2.0",
     "karma-jasmine": "^0.2.2",
@@ -40,8 +38,7 @@
     "react-mixin": "^2.0.1"
   },
   "scripts": {
-    "lint": "eslint app",
-    "build-core-js": "grunt --gruntfile node_modules/core-js/Gruntfile.js build:es5,es6,es7,js,web --blacklist=es6.number.constructor --path=core-js-no-number"
+    "lint": "eslint app"
   },
   "author": "",
   "license": "MIT"

--- a/predeploy.js
+++ b/predeploy.js
@@ -24,7 +24,7 @@ var loadClientBundleLink = path.join(dirs.meteor, 'client/loadClientBundle.html'
 var requireServerBundleJs = path.join(dirs.meteor, 'server/require.server.bundle.js');
 
 module.exports = function(callback) {
-  require('./core-js-custom-build');
+  exec('node core-js-custom-build.js');
 
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = env.NODE_ENV = 'production';

--- a/prod.js
+++ b/prod.js
@@ -26,7 +26,7 @@ var loadClientBundleHtml = path.join(dirs.webpack, 'loadClientBundle.html');
 var loadClientBundleLink = path.join(dirs.meteor, 'client/loadClientBundle.html');
 var requireServerBundleJs = path.join(dirs.meteor, 'server/require.server.bundle.js');
 
-require('./core-js-custom-build');
+exec('node core-js-custom-build.js');
 
 if (fs.existsSync(loadClientBundleLink)) rm(loadClientBundleLink);
 if (fs.existsSync(requireServerBundleJs)) rm(requireServerBundleJs);
@@ -41,7 +41,7 @@ serverCompiler.watch(serverConfig.watchOptions || {}, function(err, stats) {
     serverBundleReady = true;
     ln('-sf', serverBundlePath, serverBundleLink);
     compileClient();
-  }  
+  }
 });
 
 function compileClient() {
@@ -52,7 +52,7 @@ function compileClient() {
       clientBundleReady = true;
       ln('-sf', clientBundlePath, clientBundleLink);
       runMeteor();
-    }  
+    }
   });
 }
 


### PR DESCRIPTION
I fixed core-js build process from external packages and merge it from core-js repo. (https://github.com/zloirock/core-js/pull/120)
It released today (https://github.com/zloirock/core-js/releases/tag/v1.2.2) then I wrote custom build code. (https://github.com/zloirock/core-js#custom-build)
remove dependencies grunt and grunt-cli.

I hope this PR will be more easily handle core-js and solve https://github.com/jedwards1211/meteor-webpack-react/issues/102 issue.